### PR TITLE
Fixed text file's file path

### DIFF
--- a/multi_port_scanner.py
+++ b/multi_port_scanner.py
@@ -5,7 +5,7 @@ from socket import * # ? for opening and closing the socket connections
 
 # * VARIABLES
 # tgt_ports = [80, 443, 8080] # edit only if you have specific ports that you wish to scan
-hostnames_file_path = "E:\PYTHON\port_scanner\port_scanner_v1\hostnames.txt"
+hostnames_file_path = "./hostnames.txt"
 default_timeout = float(0.001) # ? determines how long the socket connection will try to connect for until timing out.
 
 


### PR DESCRIPTION
The old file path contained a full path for the E:\ drive, which caused an issue with running the script on any other computer. I have change the file path to only run locally, resolving the issue.